### PR TITLE
Change CSI e from CUU to CUD

### DIFF
--- a/src/vt.rs
+++ b/src/vt.rs
@@ -545,7 +545,7 @@ impl Vt {
             (None, 'a') => self.execute_cuf(),
             (None, 'b') => self.execute_rep(),
             (None, 'd') => self.execute_vpa(),
-            (None, 'e') => self.execute_cuu(),
+            (None, 'e') => self.execute_cud(),
             (None, 'f') => self.execute_cup(),
             (None, 'g') => self.execute_tbc(),
             (None, 'h') => self.execute_sm(),


### PR DESCRIPTION
`CSI e` escape sequence should move the cursor down as explained in the following documentation

- http://xtermjs.org/docs/api/vtfeatures/
- https://invisible-island.net/xterm/ctlseqs/ctlseqs.html (search for VPR)
- https://vt100.net/docs/vt510-rm/VPR.html (just for reference, it doesn't specify the direction)