### PR TITLE
Support colorspace parameter in CSI 38/48

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -917,7 +917,7 @@ impl Terminal {
                     ps = &ps[1..];
                 }
 
-                [38, 2, r, g, b] => {
+                [38, 2, r, g, b] | [38, 2, _, r, g, b] => {
                     self.pen.foreground = Some(Color::RGB(RGB8::new(*r as u8, *g as u8, *b as u8)));
                     ps = &ps[1..];
                 }
@@ -972,7 +972,7 @@ impl Terminal {
                     ps = &ps[1..];
                 }
 
-                [48, 2, r, g, b] => {
+                [48, 2, r, g, b] | [48, 2, _, r, g, b] => {
                     self.pen.background = Some(Color::RGB(RGB8::new(*r as u8, *g as u8, *b as u8)));
                     ps = &ps[1..];
                 }


### PR DESCRIPTION
One of the forms of setting foreground / background color includes an unused colorspace parameter. Unfortunately, the standard introducing it is paywaylled because ISO, but xterm documentation, the next best thing, mentions it:

> Ps = 3 8 : 2 : Pi : Pr : Pg : Pb ⇒ Set foreground color using RGB values.  If xterm is not compiled with direct-color support, it uses the closest match in its palette for the given RGB Pr/Pg/Pb.  The color space identifier Pi is ignored.

(from https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)

It’s used in practice by Neovim when communicating with foot, which leads to https://github.com/asciinema/asciinema-player/issues/268.

This PR recognizes the form with ignored colorspace parameter. I’d add tests, but I’m not sure how to specify an empty parameter in `sgr()` helper.