### PR TITLE
Support platforms without operating system

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,10 @@
-use std::cmp::Ordering;
-use std::collections::VecDeque;
-use std::ops::{Index, IndexMut, Range};
+use alloc::borrow::ToOwned as _;
+use alloc::collections::VecDeque;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::ops::{Index, IndexMut, Range};
 
 use crate::cell::Cell;
 use crate::line::Line;
@@ -351,7 +355,7 @@ impl Buffer {
 
     fn extend(&mut self, n: usize, cols: usize, pen: &Pen) {
         let line = Line::blank(cols, *pen);
-        let filler = std::iter::repeat_n(line, n);
+        let filler = core::iter::repeat_n(line, n);
         self.lines.extend(filler);
     }
 
@@ -512,7 +516,7 @@ impl<I: Iterator<Item = Line>> Iterator for Reflow<I> {
     type Item = Line;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use std::cmp::Ordering::*;
+        use core::cmp::Ordering::*;
 
         while let Some(mut line) = self.rest.take().or_else(|| self.iter.next()) {
             match self.cols.cmp(&line.len()) {
@@ -564,6 +568,9 @@ mod tests {
     use super::{Buffer, VisualPosition};
     use crate::line::Line;
     use crate::pen::Pen;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,3 +1,5 @@
+use alloc::format;
+use alloc::string::{String, ToString as _};
 use rgb::RGB8;
 use Color::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+#![no_std]
+
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
 mod buffer;
 mod cell;
 mod charset;

--- a/src/line.rs
+++ b/src/line.rs
@@ -2,7 +2,10 @@ use unicode_width::UnicodeWidthChar;
 
 use crate::cell::Cell;
 use crate::pen::Pen;
-use std::ops::{Index, Range, RangeFull};
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::{Index, Range, RangeFull};
 
 #[derive(Clone, PartialEq)]
 pub struct Line {
@@ -223,7 +226,7 @@ impl Line {
 
     pub(crate) fn expand(&mut self, len: usize, pen: &Pen) {
         let tpl = Cell::blank(*pen);
-        let filler = std::iter::repeat_n(tpl, len - self.len());
+        let filler = core::iter::repeat_n(tpl, len - self.len());
         self.cells.extend(filler);
     }
 
@@ -326,8 +329,8 @@ impl Line {
     }
 }
 
-impl std::fmt::Debug for Line {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Line {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut s = String::new();
 
         for cells in self.chunks(|c1, c2| c1.pen() != c2.pen()) {
@@ -379,7 +382,7 @@ impl<'a, I: Iterator<Item = &'a Cell>, F: Fn(&Cell, &Cell) -> bool> Iterator for
             }
 
             if (self.predicate)(self.cells.last().unwrap(), cell) {
-                let cells = std::mem::take(&mut self.cells);
+                let cells = core::mem::take(&mut self.cells);
                 self.cells.push(*cell);
                 return Some(cells);
             } else {
@@ -390,7 +393,7 @@ impl<'a, I: Iterator<Item = &'a Cell>, F: Fn(&Cell, &Cell) -> bool> Iterator for
         if self.cells.is_empty() {
             None
         } else {
-            Some(std::mem::take(&mut self.cells))
+            Some(core::mem::take(&mut self.cells))
         }
     }
 }
@@ -422,6 +425,7 @@ impl Index<RangeFull> for Line {
 #[cfg(test)]
 mod tests {
     use super::{Cell, Chunks, Pen};
+    use alloc::vec::Vec;
 
     fn chars(cells: &[Cell]) -> Vec<char> {
         cells.iter().map(|c| c.char()).collect()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,11 @@
 
 use crate::charset::Charset;
 use crate::color::Color;
-use std::fmt::Display;
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString as _;
+use alloc::vec::Vec;
+use core::fmt::Display;
 
 const PARAMS_LEN: usize = 32;
 
@@ -1058,7 +1062,7 @@ impl Param {
 }
 
 impl Display for Param {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.parts() {
             [] => unreachable!(),
 
@@ -1124,6 +1128,8 @@ mod tests {
     use super::Parser;
     use super::SgrOp::*;
     use crate::color::Color;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     fn parse(s: &str) -> Vec<Function> {
         let mut parser = Parser::new();

--- a/src/pen.rs
+++ b/src/pen.rs
@@ -1,4 +1,7 @@
 use crate::color::Color;
+use alloc::borrow::ToOwned as _;
+use alloc::format;
+use alloc::string::String;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Pen {

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -1,3 +1,6 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
 #[derive(Debug, Clone)]
 pub(crate) struct Tabs(Vec<usize>);
 
@@ -57,7 +60,7 @@ impl Tabs {
 
 impl<'a> IntoIterator for &'a Tabs {
     type Item = &'a usize;
-    type IntoIter = std::slice::Iter<'a, usize>;
+    type IntoIter = core::slice::Iter<'a, usize>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -79,6 +82,7 @@ impl PartialEq<Vec<usize>> for Tabs {
 #[cfg(test)]
 mod tests {
     use super::Tabs;
+    use alloc::vec;
 
     #[test]
     fn new() {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -11,8 +11,12 @@ use crate::parser::{
 };
 use crate::pen::{Intensity, Pen};
 use crate::tabs::Tabs;
-use std::cmp::Ordering;
-use std::mem;
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::mem;
 
 #[derive(Debug)]
 pub struct Terminal {
@@ -337,12 +341,12 @@ impl Terminal {
         let lines = self.buffer.gc();
 
         if self.active_buffer_type == BufferType::Alternate {
-            return Box::new(std::iter::empty());
+            return Box::new(core::iter::empty());
         }
 
         match lines {
             Some(iter) => Box::new(iter),
-            None => Box::new(std::iter::empty()),
+            None => Box::new(core::iter::empty()),
         }
     }
 
@@ -519,29 +523,29 @@ impl Terminal {
         let mut resized: bool = false;
 
         match cols.cmp(&self.cols) {
-            std::cmp::Ordering::Less => {
+            core::cmp::Ordering::Less => {
                 self.tabs.contract(cols);
                 resized = true;
             }
 
-            std::cmp::Ordering::Equal => {}
+            core::cmp::Ordering::Equal => {}
 
-            std::cmp::Ordering::Greater => {
+            core::cmp::Ordering::Greater => {
                 self.tabs.expand(self.cols, cols);
                 resized = true;
             }
         }
 
         match rows.cmp(&self.rows) {
-            std::cmp::Ordering::Less => {
+            core::cmp::Ordering::Less => {
                 self.top_margin = 0;
                 self.bottom_margin = rows - 1;
                 resized = true;
             }
 
-            std::cmp::Ordering::Equal => {}
+            core::cmp::Ordering::Equal => {}
 
-            std::cmp::Ordering::Greater => {
+            core::cmp::Ordering::Greater => {
                 self.top_margin = 0;
                 self.bottom_margin = rows - 1;
                 resized = true;
@@ -1570,6 +1574,7 @@ mod tests {
     use crate::color::Color;
     use crate::parser::{DecMode, Function, SgrOp};
     use crate::pen::Intensity;
+    use alloc::vec;
     use Function::*;
     use SgrOp::*;
 

--- a/src/terminal/dirty_lines.rs
+++ b/src/terminal/dirty_lines.rs
@@ -1,4 +1,6 @@
-use std::ops::Range;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ops::Range;
 
 #[derive(Debug)]
 pub struct DirtyLines(Vec<bool>);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,8 @@
 use crate::line::Line;
 use crate::vt::Vt;
-use std::mem;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::mem;
 
 #[derive(Default)]
 pub struct TextUnwrapper {
@@ -77,6 +79,9 @@ impl TextCollector {
 mod tests {
     use super::TextUnwrapper;
     use crate::{util::TextCollector, Line, Pen, Vt};
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     #[test]
     fn text_unwrapper() {

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -1,6 +1,9 @@
 use crate::line::Line;
 use crate::parser::Parser;
 use crate::terminal::{Cursor, Terminal};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 pub struct Vt {
@@ -123,6 +126,11 @@ pub struct Changes<'a> {
 mod tests {
     use super::Vt;
     use crate::line::Line;
+    use alloc::borrow::ToOwned as _;
+    use alloc::format;
+    use alloc::string::{String, ToString as _};
+    use alloc::vec;
+    use alloc::vec::Vec;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
     use std::env;


### PR DESCRIPTION
Other than for testing, nothing in this crate requires an operating system (things like `std::net::TcpStream`, `std::sync::Mutex`, `std::fs::File` etc). By adding `#![no_std]` it becomes usable for a broader set of use cases that do not have these things.