### PR TITLE
xterm.js compatibility: CSI 3 J, DECIC/DECDC, SL/SR, XTREVWRAP, combining marks, behaviour fixes

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -184,6 +184,27 @@ impl Buffer {
         self.trim_needed = true;
     }
 
+    /// Delete `n` lines starting at `range.start`, shifting the
+    /// remaining lines in `range` up and clearing the trailing `n`
+    /// rows. Unlike [`Buffer::scroll_up`], deleted lines are not
+    /// pushed into the scrollback — this matches how DL (CSI Pn M)
+    /// and SU (CSI Pn S) discard content rather than preserve it.
+    pub fn delete_lines(&mut self, range: Range<usize>, mut n: usize, pen: &Pen) {
+        n = n.min(range.end - range.start);
+
+        if range.end - 1 < self.rows - 1 {
+            self[range.end - 1].wrapped = false;
+        }
+
+        if range.start > 0 {
+            self[range.start - 1].wrapped = false;
+        }
+
+        let end = range.end;
+        self[range].rotate_left(n);
+        self.clear((end - n)..end, pen);
+    }
+
     pub fn scroll_down(&mut self, range: Range<usize>, mut n: usize, pen: &Pen) {
         let (start, end) = (range.start, range.end);
         n = n.min(end - start);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -85,6 +85,14 @@ impl Buffer {
         self[row].print(col, ch, pen)
     }
 
+    /// Append a zero-width combining mark to the cell at `(col,
+    /// row)`. Caller is responsible for choosing the right anchor
+    /// column when the cursor sits on a wide-tail or in the
+    /// overshoot position.
+    pub fn push_combining(&mut self, (col, row): VisualPosition, ch: char) {
+        self[row].cells[col].push_combining(ch);
+    }
+
     pub fn wrap(&mut self, row: usize) {
         self[row].wrapped = true;
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -355,6 +355,14 @@ impl Buffer {
         self.lines.extend(filler);
     }
 
+    /// Drop all scrollback lines, keeping the visible view intact.
+    pub fn clear_scrollback(&mut self) {
+        let offset = self.view_offset();
+        if offset > 0 {
+            self.lines.drain(..offset);
+        }
+    }
+
     fn trim_scrollback(&mut self) -> Option<impl Iterator<Item = Line> + '_> {
         if let Some(limit) = &self.scrollback_limit {
             let line_count = self.lines.len();

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -1,7 +1,16 @@
 use crate::pen::Pen;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct Cell(char, Occupancy, Pen);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cell {
+    ch: char,
+    occupancy: Occupancy,
+    pen: Pen,
+    /// Zero-width combining marks attached to this cell's base
+    /// character. They render after the base, never get their own
+    /// column. Empty for the overwhelming majority of cells, which
+    /// is why this lives behind an allocation rather than inline.
+    combining: Vec<char>,
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum Occupancy {
@@ -22,37 +31,54 @@ impl Occupancy {
 
 impl Cell {
     pub(crate) fn new(ch: char, occupancy: Occupancy, pen: Pen) -> Self {
-        Cell(ch, occupancy, pen)
+        Cell {
+            ch,
+            occupancy,
+            pen,
+            combining: Vec::new(),
+        }
     }
 
     pub(crate) fn blank(pen: Pen) -> Self {
-        Cell(' ', Occupancy::Single, pen)
+        Self::new(' ', Occupancy::Single, pen)
     }
 
     pub fn is_default(&self) -> bool {
-        self.0 == ' ' && self.1 == Occupancy::Single && self.2.is_default()
+        self.ch == ' '
+            && self.occupancy == Occupancy::Single
+            && self.pen.is_default()
+            && self.combining.is_empty()
     }
 
     pub fn char(&self) -> char {
-        self.0
+        self.ch
+    }
+
+    pub fn combining(&self) -> &[char] {
+        &self.combining
     }
 
     pub(crate) fn occupancy(&self) -> Occupancy {
-        self.1
+        self.occupancy
     }
 
     pub fn width(&self) -> u8 {
-        self.1.width()
+        self.occupancy.width()
     }
 
     pub fn pen(&self) -> &Pen {
-        &self.2
+        &self.pen
     }
 
     pub(crate) fn set(&mut self, ch: char, occupancy: Occupancy, pen: Pen) {
-        self.0 = ch;
-        self.1 = occupancy;
-        self.2 = pen;
+        self.ch = ch;
+        self.occupancy = occupancy;
+        self.pen = pen;
+        self.combining.clear();
+    }
+
+    pub(crate) fn push_combining(&mut self, ch: char) {
+        self.combining.push(ch);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ pub use charset::Charset;
 pub use color::Color;
 pub use line::Line;
 pub use pen::Pen;
+pub use terminal::BufferType;
 pub use vt::Vt;

--- a/src/line.rs
+++ b/src/line.rs
@@ -212,7 +212,7 @@ impl Line {
                 self.cells.push(Cell::new(' ', Occupancy::Single, *pen));
             }
 
-            self.cells.extend(&other[0..needed]);
+            self.cells.extend(other[0..needed].iter().cloned());
             let mut cells = other.cells;
             cells.rotate_left(needed);
             cells.truncate(cells.len() - needed);
@@ -226,7 +226,7 @@ impl Line {
             );
         }
 
-        self.cells.extend(&other[..]);
+        self.cells.extend(other[..].iter().cloned());
 
         if !other.wrapped {
             self.wrapped = false;
@@ -312,12 +312,13 @@ impl Line {
     }
 
     pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
-        self.cells.iter().filter_map(|c| {
-            if c.occupancy() != Occupancy::WideTail {
+        self.cells.iter().flat_map(|c| {
+            let base = if c.occupancy() != Occupancy::WideTail {
                 Some(c.char())
             } else {
                 None
-            }
+            };
+            base.into_iter().chain(c.combining().iter().copied())
         })
     }
 
@@ -392,16 +393,16 @@ impl<'a, I: Iterator<Item = &'a Cell>, F: Fn(&Cell, &Cell) -> bool> Iterator for
     fn next(&mut self) -> Option<Self::Item> {
         for cell in self.iter.by_ref() {
             if self.cells.is_empty() {
-                self.cells.push(*cell);
+                self.cells.push(cell.clone());
                 continue;
             }
 
             if (self.predicate)(self.cells.last().unwrap(), cell) {
                 let cells = std::mem::take(&mut self.cells);
-                self.cells.push(*cell);
+                self.cells.push(cell.clone());
                 return Some(cells);
             } else {
-                self.cells.push(*cell);
+                self.cells.push(cell.clone());
             }
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -113,6 +113,7 @@ pub enum DecMode {
     Origin = 6,                       // DECOM
     AutoWrap = 7,                     // DECAWM
     TextCursorEnable = 25,            // DECTCEM
+    ReverseWrap = 45,                 // XTREVWRAP
     AltScreenBuffer = 1047,           // xterm
     SaveCursor = 1048,                // xterm
     SaveCursorAltScreenBuffer = 1049, // xterm
@@ -1024,6 +1025,7 @@ fn dump_function(seq: &mut String, fun: &Function) {
                     Origin => 6,
                     AutoWrap => 7,
                     TextCursorEnable => 25,
+                    ReverseWrap => 45,
                     AltScreenBuffer => 1047,
                     SaveCursor => 1048,
                     SaveCursorAltScreenBuffer => 1049,
@@ -1045,6 +1047,7 @@ fn dump_function(seq: &mut String, fun: &Function) {
                     Origin => 6,
                     AutoWrap => 7,
                     TextCursorEnable => 25,
+                    ReverseWrap => 45,
                     AltScreenBuffer => 1047,
                     SaveCursor => 1048,
                     SaveCursorAltScreenBuffer => 1049,
@@ -1522,6 +1525,7 @@ fn dec_mode(param: &Param) -> Option<DecMode> {
         6 => Some(Origin),
         7 => Some(AutoWrap),
         25 => Some(TextCursorEnable),
+        45 => Some(ReverseWrap),
         47 => Some(AltScreenBuffer), // legacy variant of 1047
         1047 => Some(AltScreenBuffer),
         1048 => Some(SaveCursor),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,8 +81,10 @@ pub enum Function {
     Sd(u16),
     Sgr(SgrOps),
     Si,
+    Sl(u16),
     Sm(AnsiModes),
     So,
+    Sr(u16),
     Su(u16),
     Tbc(TbcScope),
     Vpa(u16),
@@ -822,6 +824,10 @@ impl Parser {
 
             (Some('\''), '~') => Some(Decdc(ps[0].as_u16())),
 
+            (Some(' '), '@') => Some(Sl(ps[0].as_u16())),
+
+            (Some(' '), 'A') => Some(Sr(ps[0].as_u16())),
+
             (Some('?'), 'h') => Some(Decset(DecModes::collect(
                 ps[..=self.cur_param].iter().filter_map(dec_mode),
             ))),
@@ -1176,7 +1182,9 @@ fn dump_function(seq: &mut String, fun: &Function) {
             push_csi(seq, None, &params, 'h');
         }
 
+        Sl(n) => push_csi(seq, Some(' '), &[n.to_string()], '@'),
         So => seq.push('\u{0e}'),
+        Sr(n) => push_csi(seq, Some(' '), &[n.to_string()], 'A'),
         Su(n) => push_csi(seq, None, &[n.to_string()], 'S'),
 
         Tbc(scope) => {
@@ -1837,6 +1845,10 @@ mod tests {
         assert_eq!(parse("\x1b[2'}"), [Decic(2)]);
         assert_eq!(parse("\x1b['~"), [Decdc(0)]);
         assert_eq!(parse("\x1b[3'~"), [Decdc(3)]);
+        assert_eq!(parse("\x1b[ @"), [Sl(0)]);
+        assert_eq!(parse("\x1b[4 @"), [Sl(4)]);
+        assert_eq!(parse("\x1b[ A"), [Sr(0)]);
+        assert_eq!(parse("\x1b[5 A"), [Sr(5)]);
 
         // DEC private modes.
         assert_eq!(parse("\x1b[?7h"), [Decset(dec_modes([DecMode::AutoWrap]))]);
@@ -2186,9 +2198,11 @@ mod tests {
                 ResetBackgroundColor,
             ])),
             Si,
+            Sl(7),
             Sm(ansi_modes([])),
             Sm(ansi_modes([AnsiMode::Insert, AnsiMode::NewLine])),
             So,
+            Sr(8),
             Su(19),
             Tbc(TbcScope::CurrentColumn),
             Tbc(TbcScope::All),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,6 +51,8 @@ pub enum Function {
     Cuu(u16),
     Dch(u16),
     Decaln,
+    Decdc(u16),
+    Decic(u16),
     Decrc,
     Decrst(DecModes),
     Decsc,
@@ -816,6 +818,10 @@ impl Parser {
 
             (Some('!'), 'p') => Some(Decstr),
 
+            (Some('\''), '}') => Some(Decic(ps[0].as_u16())),
+
+            (Some('\''), '~') => Some(Decdc(ps[0].as_u16())),
+
             (Some('?'), 'h') => Some(Decset(DecModes::collect(
                 ps[..=self.cur_param].iter().filter_map(dec_mode),
             ))),
@@ -999,6 +1005,8 @@ fn dump_function(seq: &mut String, fun: &Function) {
         Cuu(n) => push_csi(seq, None, &[n.to_string()], 'A'),
         Dch(n) => push_csi(seq, None, &[n.to_string()], 'P'),
         Decaln => push_esc(seq, Some('#'), '8'),
+        Decdc(n) => push_csi(seq, Some('\''), &[n.to_string()], '~'),
+        Decic(n) => push_csi(seq, Some('\''), &[n.to_string()], '}'),
         Decrc => push_esc(seq, None, '8'),
 
         Decrst(modes) => {
@@ -1208,8 +1216,23 @@ fn push_csi(seq: &mut String, intermediate: Option<char>, params: &[String], fin
     seq.push('\u{1b}');
     seq.push('[');
 
-    if let Some(intermediate) = intermediate {
-        seq.push(intermediate);
+    // Private-mode prefixes (`<` `=` `>` `?`, i.e. 0x3c..=0x3f) and
+    // every other intermediate byte sit on different sides of the
+    // parameter run in ECMA-48:
+    //
+    //   - private prefix: immediately after CSI, before any param
+    //   - intermediate byte (0x20..=0x2f): after params, before the
+    //     final character
+    //
+    // The parser's state machine reflects that split (`CsiParam`
+    // after a private prefix accepts params; `CsiIntermediate`
+    // discards them via `CsiIgnore`). Emit in the form the parser
+    // round-trips cleanly.
+    let private = intermediate.filter(|c| matches!(*c, '\u{3c}'..='\u{3f}'));
+    let after_params = intermediate.filter(|c| !matches!(*c, '\u{3c}'..='\u{3f}'));
+
+    if let Some(c) = private {
+        seq.push(c);
     }
 
     if let Some((first, rest)) = params.split_first() {
@@ -1219,6 +1242,10 @@ fn push_csi(seq: &mut String, intermediate: Option<char>, params: &[String], fin
             seq.push(';');
             seq.push_str(param);
         }
+    }
+
+    if let Some(c) = after_params {
+        seq.push(c);
     }
 
     seq.push(final_char);
@@ -1806,6 +1833,10 @@ mod tests {
         assert_eq!(parse("\x1b[s"), [Scosc]);
         assert_eq!(parse("\x1b[u"), [Scorc]);
         assert_eq!(parse("\x1b[!p"), [Decstr]);
+        assert_eq!(parse("\x1b['}"), [Decic(0)]);
+        assert_eq!(parse("\x1b[2'}"), [Decic(2)]);
+        assert_eq!(parse("\x1b['~"), [Decdc(0)]);
+        assert_eq!(parse("\x1b[3'~"), [Decdc(3)]);
 
         // DEC private modes.
         assert_eq!(parse("\x1b[?7h"), [Decset(dec_modes([DecMode::AutoWrap]))]);
@@ -2078,6 +2109,8 @@ mod tests {
             Cuu(1),
             Dch(18),
             Decaln,
+            Decdc(3),
+            Decic(2),
             Decrc,
             Decrst(dec_modes([])),
             Decrst(dec_modes([

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -870,6 +870,10 @@ impl Terminal {
 
             self.dirty_lines.add(row);
         }
+
+        // DECALN homes the cursor as part of the alignment test.
+        self.cursor.col = 0;
+        self.cursor.row = 0;
     }
 
     fn gzd4(&mut self, charset: Charset) {
@@ -3123,8 +3127,10 @@ mod tests {
         term.execute(Cup(2, 3));
         term.execute(Decaln);
 
-        assert_eq!(term.cursor(), (2, 1));
-        assert_eq!(text(&term), "EEEE\nEE|EE");
+        // Per VT100: DECALN fills the screen with the test pattern
+        // AND homes the cursor as part of the alignment check.
+        assert_eq!(term.cursor(), (0, 0));
+        assert_eq!(text(&term), "|EEEE\nEEEE");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -32,6 +32,7 @@ pub struct Terminal {
     insert_mode: bool,
     origin_mode: bool,
     auto_wrap_mode: bool,
+    reverse_wrap_mode: bool,
     new_line_mode: bool,
     cursor_keys_mode: CursorKeysMode,
     top_margin: usize,
@@ -123,6 +124,7 @@ impl Terminal {
             insert_mode: false,
             origin_mode: false,
             auto_wrap_mode: true,
+            reverse_wrap_mode: false,
             new_line_mode: false,
             cursor_keys_mode: CursorKeysMode::Normal,
             top_margin: 0,
@@ -646,6 +648,7 @@ impl Terminal {
         self.insert_mode = false;
         self.origin_mode = false;
         self.auto_wrap_mode = true;
+        self.reverse_wrap_mode = false;
         self.new_line_mode = false;
         self.cursor_keys_mode = CursorKeysMode::Normal;
         self.top_margin = 0;
@@ -723,6 +726,7 @@ impl Terminal {
         assert_eq!(self.insert_mode, other.insert_mode);
         assert_eq!(self.origin_mode, other.origin_mode);
         assert_eq!(self.auto_wrap_mode, other.auto_wrap_mode);
+        assert_eq!(self.reverse_wrap_mode, other.reverse_wrap_mode);
         assert_eq!(self.new_line_mode, other.new_line_mode);
         assert_eq!(self.cursor_keys_mode, other.cursor_keys_mode);
         assert_eq!(self.top_margin, other.top_margin);
@@ -835,6 +839,19 @@ impl Terminal {
     }
 
     fn bs(&mut self) {
+        // XTREVWRAP (DEC private mode 45) makes BS at column 0 of a
+        // soft-wrapped continuation row hop back to the last column
+        // of the preceding row. Without it BS is clamped at col 0.
+        if self.cursor.col == 0
+            && self.reverse_wrap_mode
+            && self.cursor.row > 0
+            && self.buffer[self.cursor.row - 1].wrapped
+        {
+            self.cursor.row -= 1;
+            self.cursor.col = self.cols - 1;
+            return;
+        }
+
         if self.cursor.col == self.cols {
             self.move_cursor_to_rel_col(-2);
         } else {
@@ -1394,6 +1411,10 @@ impl Terminal {
                     self.auto_wrap_mode = true;
                 }
 
+                ReverseWrap => {
+                    self.reverse_wrap_mode = true;
+                }
+
                 TextCursorEnable => {
                     self.cursor.visible = true;
                 }
@@ -1432,6 +1453,10 @@ impl Terminal {
 
                 AutoWrap => {
                     self.auto_wrap_mode = false;
+                }
+
+                ReverseWrap => {
+                    self.reverse_wrap_mode = false;
                 }
 
                 TextCursorEnable => {
@@ -2170,6 +2195,52 @@ mod tests {
         term.execute(Bs);
 
         assert_eq!(text(&term), "abcd\n|ef");
+    }
+
+    #[test]
+    fn execute_bs_with_reverse_wrap() {
+        // DECSET 45 (XTREVWRAP) makes BS at column 0 cross over to
+        // the last column of the previous row, but only when the
+        // previous row is soft-wrapped (continued onto the current
+        // row). Hard line breaks block the rewind.
+        let mut term = Terminal::new((4, 3), None);
+
+        term.execute(Decset(dec_modes([DecMode::ReverseWrap])));
+
+        // Soft-wrapped row: fill row 0 and let auto-wrap push into
+        // row 1.
+        feed(&mut term, "abcdef");
+        assert_eq!(term.cursor(), (2, 1));
+
+        // BS at col 2 → col 1, normal step.
+        term.execute(Bs);
+        assert_eq!(term.cursor(), (1, 1));
+
+        // BS at col 1 → col 0, still inside the same row.
+        term.execute(Bs);
+        assert_eq!(term.cursor(), (0, 1));
+
+        // BS at col 0 with a soft-wrapped predecessor → last col of
+        // the previous row.
+        term.execute(Bs);
+        assert_eq!(term.cursor(), (3, 0));
+    }
+
+    #[test]
+    fn execute_bs_with_reverse_wrap_stops_at_hard_break() {
+        // Reverse-wrap should not cross hard line breaks (CR/LF).
+        let mut term = Terminal::new((4, 3), None);
+
+        term.execute(Decset(dec_modes([DecMode::ReverseWrap])));
+        feed(&mut term, "ab\r\ncd");
+        // Cursor sits at row 1, col 2. Walk it back to col 0.
+        term.execute(Bs);
+        term.execute(Bs);
+        assert_eq!(term.cursor(), (0, 1));
+
+        // BS at col 0 with a hard-break predecessor stays put.
+        term.execute(Bs);
+        assert_eq!(term.cursor(), (0, 1));
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -91,8 +91,15 @@ impl SavedCtx {
 }
 
 enum PrintResult {
+    /// Glyph landed at the current cell with `width` advance.
     Printed(usize),
-    NeedsRelocation,
+    /// Cursor was already past the last column when the print
+    /// started (the auto-wrap "pending-wrap" state).
+    Overshoot,
+    /// Cursor is still inside the screen but the glyph would
+    /// straddle the right edge — i.e. a wide glyph reaching the
+    /// last column.
+    WideAtEdge,
 }
 
 impl Terminal {
@@ -741,10 +748,20 @@ impl Terminal {
 
         match self.try_print(ch) {
             PrintResult::Printed(width) => self.advance_cursor_after_print(width),
-            PrintResult::NeedsRelocation if self.auto_wrap_mode => {
+            PrintResult::Overshoot if self.auto_wrap_mode => {
                 self.wrap_and_print_at_line_start(ch)
             }
-            PrintResult::NeedsRelocation => self.print_at_line_end(ch),
+            PrintResult::Overshoot => self.print_at_line_end(ch),
+            PrintResult::WideAtEdge if self.auto_wrap_mode => {
+                self.wrap_and_print_at_line_start(ch)
+            }
+            // A wide glyph that doesn't fit while auto-wrap is off
+            // is silently discarded — xterm.js drops it and leaves
+            // the cursor anchored at the last column. Earlier
+            // versions of this emulator overwrote the previous cell
+            // with the wide glyph, which produced visible junk and
+            // moved the cursor into the overshoot column.
+            PrintResult::WideAtEdge => {}
         }
 
         self.last_print_char = Some(ch);
@@ -753,7 +770,7 @@ impl Terminal {
 
     fn try_print(&mut self, ch: char) -> PrintResult {
         if self.cursor.col >= self.cols {
-            return PrintResult::NeedsRelocation;
+            return PrintResult::Overshoot;
         }
 
         if self.insert_mode {
@@ -766,7 +783,7 @@ impl Terminal {
             .print((self.cursor.col, self.cursor.row), ch, self.pen)
         {
             Some(width) => PrintResult::Printed(width),
-            None => PrintResult::NeedsRelocation,
+            None => PrintResult::WideAtEdge,
         }
     }
 
@@ -3093,6 +3110,24 @@ mod tests {
                 (' ', Occupancy::WideTail),
             ]
         );
+    }
+
+    #[test]
+    fn print_wide_char_at_last_column_no_autowrap_drops_glyph() {
+        // 5-column row, auto-wrap off. After "ABCD" the cursor sits
+        // at the last column (col 4), with that cell still blank —
+        // we haven't yet entered the pending-wrap state. A wide
+        // glyph that would straddle the right edge is dropped and
+        // the cursor stays anchored.
+        let mut term = Terminal::new((5, 1), None);
+        term.execute(Decrst(dec_modes([DecMode::AutoWrap])));
+        feed(&mut term, "ABCD");
+        assert_eq!(term.cursor(), (4, 0));
+
+        term.execute(Print('你'));
+
+        assert_eq!(term.cursor(), (4, 0));
+        assert_eq!(text(&term), "ABCD|");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1727,6 +1727,12 @@ impl Terminal {
             funs.push(Function::Decrst(DecModes::one(DecMode::AutoWrap)));
         }
 
+        // 12b. setup reverse-wrap mode
+
+        if self.reverse_wrap_mode {
+            funs.push(Function::Decset(DecModes::one(DecMode::ReverseWrap)));
+        }
+
         // 13. setup new line mode
 
         if self.new_line_mode {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -209,6 +209,14 @@ impl Terminal {
                 self.decaln();
             }
 
+            Decdc(n) => {
+                self.decdc(n);
+            }
+
+            Decic(n) => {
+                self.decic(n);
+            }
+
             Decrc => {
                 self.rc();
             }
@@ -860,6 +868,48 @@ impl Terminal {
 
     fn ris(&mut self) {
         self.hard_reset();
+    }
+
+    /// DECIC (CSI Pn ' }) — Insert `n` columns at the cursor column,
+    /// shifting cells to the right within each row of the active
+    /// scroll region. Columns shifted past the right edge are lost.
+    fn decic(&mut self, n: u16) {
+        let n = as_usize(n, 1);
+        let cols_left = self.cols.saturating_sub(self.cursor.col);
+        let shift = n.min(cols_left);
+        if shift == 0 {
+            return;
+        }
+        let col = self.cursor.col;
+        let rows = self.top_margin..self.bottom_margin + 1;
+        for row in rows.clone() {
+            self.buffer.shift_right((col, row), shift, self.pen);
+            // shift_right rotates the cells in place; we still need
+            // to blank the freshly inserted columns at the cursor.
+            for c in col..col + shift {
+                self.buffer.print((c, row), ' ', self.pen);
+            }
+        }
+        self.dirty_lines.extend(rows);
+    }
+
+    /// DECDC (CSI Pn ' ~) — Delete `n` columns at the cursor column,
+    /// shifting cells left within each row of the active scroll
+    /// region. The freed columns at the right edge are filled with
+    /// blanks using the active pen.
+    fn decdc(&mut self, n: u16) {
+        let n = as_usize(n, 1);
+        let cols_left = self.cols.saturating_sub(self.cursor.col);
+        let shift = n.min(cols_left);
+        if shift == 0 {
+            return;
+        }
+        let col = self.cursor.col;
+        let rows = self.top_margin..self.bottom_margin + 1;
+        for row in rows.clone() {
+            self.buffer.delete((col, row), shift, &self.pen);
+        }
+        self.dirty_lines.extend(rows);
     }
 
     fn decaln(&mut self) {
@@ -2707,6 +2757,48 @@ mod tests {
         term.execute(Dch(10));
 
         assert_eq!(text(&term), "abc    |\nijkl");
+    }
+
+    #[test]
+    fn execute_decic() {
+        // DECIC: insert columns at the cursor column in every row of
+        // the active scroll region, shifting existing cells right.
+        // Columns past the right margin are dropped.
+        let mut term = build_term(8, 2, 2, 0, "abcdefghIJKLMNOP");
+
+        term.execute(Decic(3));
+
+        assert_eq!(text(&term), "ab|   cde\nIJ   KLM");
+    }
+
+    #[test]
+    fn execute_decic_default_param_is_one() {
+        let mut term = build_term(8, 1, 0, 0, "abcdefgh");
+
+        term.execute(Decic(0));
+
+        assert_eq!(text(&term), "| abcdefg");
+    }
+
+    #[test]
+    fn execute_decdc() {
+        // DECDC: delete columns at the cursor column in every row of
+        // the active scroll region, shifting existing cells left.
+        // Freed cells at the right edge are blanked.
+        let mut term = build_term(8, 2, 2, 0, "abcdefghIJKLMNOP");
+
+        term.execute(Decdc(3));
+
+        assert_eq!(text(&term), "ab|fgh\nIJNOP");
+    }
+
+    #[test]
+    fn execute_decdc_default_param_is_one() {
+        let mut term = build_term(8, 1, 0, 0, "abcdefgh");
+
+        term.execute(Decdc(0));
+
+        assert_eq!(text(&term), "|bcdefgh");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -40,6 +40,11 @@ pub struct Terminal {
     alternate_saved_ctx: SavedCtx,
     dirty_lines: DirtyLines,
     xtwinops: bool,
+    /// Last printable character emitted, used by REP (CSI Pn b).
+    /// Cleared by every non-print / non-REP function so a cursor
+    /// move between the print and REP makes REP a no-op (matching
+    /// the de-facto xterm behavior).
+    last_print_char: Option<char>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -119,6 +124,7 @@ impl Terminal {
             alternate_saved_ctx: SavedCtx::default(),
             dirty_lines,
             xtwinops: false,
+            last_print_char: None,
         }
     }
 
@@ -132,6 +138,15 @@ impl Terminal {
 
     pub fn execute(&mut self, fun: Function) {
         use Function::*;
+
+        // REP repeats the last printable. Any other function — even
+        // a cursor move that doesn't visibly change buffer state —
+        // invalidates that history, so a `print "X"; cup ...; rep`
+        // sequence is a no-op rather than replaying whatever cell
+        // happens to be next to the new cursor position.
+        if !matches!(fun, Print(_) | Rep(_)) {
+            self.last_print_char = None;
+        }
 
         match fun {
             Bs => {
@@ -716,6 +731,7 @@ impl Terminal {
             PrintResult::NeedsRelocation => self.print_at_line_end(ch),
         }
 
+        self.last_print_char = Some(ch);
         self.dirty_lines.add(self.cursor.row);
     }
 
@@ -1083,19 +1099,11 @@ impl Terminal {
     }
 
     fn rep(&mut self, n: u16) {
-        if self.cursor.col > 0 {
+        if let Some(ch) = self.last_print_char {
             let n = as_usize(n, 1);
-            let row = self.cursor.row;
-            let mut col = self.cursor.col - 1;
 
-            while col > 0 && self.buffer[(col, row)].occupancy() == Occupancy::WideTail {
-                col -= 1;
-            }
-
-            let char = self.buffer[(col, row)].char();
-
-            for _n in 0..n {
-                self.print(char);
+            for _ in 0..n {
+                self.print(ch);
             }
         }
     }
@@ -2278,6 +2286,7 @@ mod tests {
     fn execute_rep() {
         let mut term = build_term(20, 2, 0, 0, "");
 
+        // REP with no preceding printable is a no-op.
         term.execute(Rep(0));
 
         assert_eq!(text(&term), "|\n");
@@ -2291,10 +2300,40 @@ mod tests {
 
         assert_eq!(text(&term), "AAAAA|\n");
 
+        // A cursor move invalidates the REP history; the following
+        // REP is a no-op.
         term.execute(Cuf(5));
         term.execute(Rep(0));
 
-        assert_eq!(text(&term), "AAAAA      |\n");
+        assert_eq!(text(&term), "AAAAA     |\n");
+    }
+
+    #[test]
+    fn rep_is_noop_after_cursor_movement() {
+        // Print 'A', explicitly move the cursor, then REP. With the
+        // last-print history cleared by every non-print operation,
+        // REP repeats nothing — the cells past the new cursor
+        // position stay blank.
+        let mut term = build_term(10, 1, 0, 0, "");
+
+        term.execute(Print('A'));
+        term.execute(Cup(1, 4));
+        term.execute(Rep(3));
+
+        assert_eq!(text(&term), "A  |");
+    }
+
+    #[test]
+    fn rep_chains_consecutively() {
+        // Two REPs in a row both repeat the last printable. Only a
+        // non-print/non-REP function would clear the history.
+        let mut term = build_term(10, 1, 0, 0, "");
+
+        term.execute(Print('A'));
+        term.execute(Rep(2));
+        term.execute(Rep(2));
+
+        assert_eq!(text(&term), "AAAAA|");
     }
 
     #[test]
@@ -2313,9 +2352,10 @@ mod tests {
 
         term.execute(Print('ハ'));
         term.execute(Cub(1));
+        // Cursor moved → REP has nothing to repeat.
         term.execute(Rep(3));
 
-        assert_eq!(text(&term), " ハハハ|\n");
+        assert_eq!(text(&term), "|ハ\n");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -739,11 +739,15 @@ impl Terminal {
     }
 
     fn advance_cursor_after_print(&mut self, width: usize) {
+        // Let the cursor sit at `cols` after a print that fills the
+        // last column. With auto-wrap on, the next printable advances
+        // via `wrap_and_print_at_line_start`; with auto-wrap off, the
+        // next printable is dispatched to `print_at_line_end`, which
+        // overwrites at `cols - 1` and leaves the cursor at `cols`.
+        // Either way, keeping the overshoot state visible matches the
+        // observable cursor position that interactive terminals (and
+        // xterm.js) report.
         self.cursor.col += width;
-
-        if self.cursor.col == self.cols && !self.auto_wrap_mode {
-            self.cursor.col = self.cols - 1;
-        }
     }
 
     fn wrap_and_print_at_line_start(&mut self, ch: char) {
@@ -774,7 +778,11 @@ impl Terminal {
             }
         }
 
-        self.cursor.col = self.cols - 1;
+        // Park the cursor in the "overshoot" position past the last
+        // column. With auto-wrap off, a subsequent print overwrites
+        // the same cell; toggling auto-wrap back on lets the next
+        // print wrap to a new row.
+        self.cursor.col = self.cols;
     }
 
     fn bs(&mut self) {
@@ -2696,6 +2704,25 @@ mod tests {
     }
 
     #[test]
+    fn auto_wrap_re_enabled_after_overshoot_wraps_next_print() {
+        // Fill the row with auto-wrap off, leaving the cursor in
+        // the overshoot position past the last column; re-enable
+        // auto-wrap; verify the next printable wraps to a new row.
+        let mut term = Terminal::new((4, 4), None);
+
+        term.execute(Decrst(dec_modes([DecMode::AutoWrap])));
+        feed(&mut term, "abcd");
+
+        assert_eq!(term.cursor(), (4, 0));
+
+        term.execute(Decset(dec_modes([DecMode::AutoWrap])));
+        feed(&mut term, "e");
+
+        assert_eq!(term.cursor(), (1, 1));
+        assert_eq!(text(&term), "abcd\ne|\n\n");
+    }
+
+    #[test]
     fn auto_wrap_mode() {
         let mut term = Terminal::new((4, 4), None);
 
@@ -2709,7 +2736,12 @@ mod tests {
         term.execute(Decrst(dec_modes([DecMode::AutoWrap])));
         feed(&mut term, "abcdef");
 
-        assert_eq!(text(&term), "abc|f\n\n\n");
+        // Auto-wrap off: after filling the row, every subsequent
+        // printable overwrites the last column. The cursor parks one
+        // past the last column (the "overshoot" state) so flipping
+        // auto-wrap back on lets the next character wrap to a new
+        // row.
+        assert_eq!(text(&term), "abcf|\n\n\n");
     }
 
     #[test]
@@ -2813,8 +2845,12 @@ mod tests {
         term.execute(Cub(1));
         term.execute(Print('界'));
 
-        assert_eq!(term.cursor(), (3, 0));
-        assert_eq!(text(&term), "A |界\n");
+        // Auto-wrap off: 界 doesn't fit at col 3 (a single col left),
+        // so it gets placed one column back, overwriting the
+        // wide-tail of ハ. The cursor parks in the overshoot
+        // position past the last column.
+        assert_eq!(term.cursor(), (4, 0));
+        assert_eq!(text(&term), "A 界|\n");
         assert_eq!(wrapped(&term), vec![false, false]);
 
         let row0 = term.view().next().unwrap();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -757,13 +757,9 @@ impl Terminal {
 
         match self.try_print(ch) {
             PrintResult::Printed(width) => self.advance_cursor_after_print(width),
-            PrintResult::Overshoot if self.auto_wrap_mode => {
-                self.wrap_and_print_at_line_start(ch)
-            }
+            PrintResult::Overshoot if self.auto_wrap_mode => self.wrap_and_print_at_line_start(ch),
             PrintResult::Overshoot => self.print_at_line_end(ch),
-            PrintResult::WideAtEdge if self.auto_wrap_mode => {
-                self.wrap_and_print_at_line_start(ch)
-            }
+            PrintResult::WideAtEdge if self.auto_wrap_mode => self.wrap_and_print_at_line_start(ch),
             // A wide glyph that doesn't fit while auto-wrap is off
             // is silently discarded — xterm.js drops it and leaves
             // the cursor anchored at the last column. Earlier
@@ -1701,19 +1697,27 @@ impl Terminal {
 
         if self.cursor.col >= self.cols {
             // move cursor past the right border by re-printing the character in
-            // the last column
+            // the last column. Trailing combining marks on the trigger cell
+            // get re-emitted as their own Print functions so the round-trip
+            // doesn't strip them when the re-print clears the destination.
             let last_cell = &self.buffer[(self.cols - 1, self.cursor.row)];
             let occupancy = last_cell.occupancy();
 
             if occupancy == Occupancy::Single {
                 funs.push(to_sgr(last_cell.pen()));
                 funs.push(Function::Print(last_cell.char()));
+                for mark in last_cell.combining() {
+                    funs.push(Function::Print(*mark));
+                }
             } else if occupancy == Occupancy::WideTail {
                 let prev_cell = &self.buffer[(self.cols - 2, self.cursor.row)];
 
                 funs.push(Function::Cub(1));
                 funs.push(to_sgr(prev_cell.pen()));
                 funs.push(Function::Print(prev_cell.char()));
+                for mark in prev_cell.combining() {
+                    funs.push(Function::Print(*mark));
+                }
             }
         }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -329,12 +329,20 @@ impl Terminal {
                 self.si();
             }
 
+            Sl(n) => {
+                self.sl(n);
+            }
+
             Sm(modes) => {
                 self.sm(modes);
             }
 
             So => {
                 self.so();
+            }
+
+            Sr(n) => {
+                self.sr(n);
             }
 
             Su(n) => {
@@ -874,23 +882,7 @@ impl Terminal {
     /// shifting cells to the right within each row of the active
     /// scroll region. Columns shifted past the right edge are lost.
     fn decic(&mut self, n: u16) {
-        let n = as_usize(n, 1);
-        let cols_left = self.cols.saturating_sub(self.cursor.col);
-        let shift = n.min(cols_left);
-        if shift == 0 {
-            return;
-        }
-        let col = self.cursor.col;
-        let rows = self.top_margin..self.bottom_margin + 1;
-        for row in rows.clone() {
-            self.buffer.shift_right((col, row), shift, self.pen);
-            // shift_right rotates the cells in place; we still need
-            // to blank the freshly inserted columns at the cursor.
-            for c in col..col + shift {
-                self.buffer.print((c, row), ' ', self.pen);
-            }
-        }
-        self.dirty_lines.extend(rows);
+        self.insert_columns(self.cursor.col, n);
     }
 
     /// DECDC (CSI Pn ' ~) — Delete `n` columns at the cursor column,
@@ -898,13 +890,53 @@ impl Terminal {
     /// region. The freed columns at the right edge are filled with
     /// blanks using the active pen.
     fn decdc(&mut self, n: u16) {
+        self.delete_columns(self.cursor.col, n);
+    }
+
+    /// SL (CSI Pn SP @) — Scroll left by `n` columns. Every row in
+    /// the active scroll region shifts left by `n`; the leftmost
+    /// columns are dropped and freed columns at the right edge are
+    /// blanked with the active pen. Equivalent to DECDC anchored at
+    /// column 0. The cursor does not move.
+    fn sl(&mut self, n: u16) {
+        self.delete_columns(0, n);
+    }
+
+    /// SR (CSI Pn SP A) — Scroll right by `n` columns. Every row in
+    /// the active scroll region shifts right by `n`; the rightmost
+    /// columns are dropped and freed columns at the left edge are
+    /// blanked with the active pen. Equivalent to DECIC anchored at
+    /// column 0. The cursor does not move.
+    fn sr(&mut self, n: u16) {
+        self.insert_columns(0, n);
+    }
+
+    fn insert_columns(&mut self, col: usize, n: u16) {
         let n = as_usize(n, 1);
-        let cols_left = self.cols.saturating_sub(self.cursor.col);
+        let cols_left = self.cols.saturating_sub(col);
         let shift = n.min(cols_left);
         if shift == 0 {
             return;
         }
-        let col = self.cursor.col;
+        let rows = self.top_margin..self.bottom_margin + 1;
+        for row in rows.clone() {
+            self.buffer.shift_right((col, row), shift, self.pen);
+            // shift_right rotates the cells in place; the freshly
+            // inserted columns still need to be blanked.
+            for c in col..col + shift {
+                self.buffer.print((c, row), ' ', self.pen);
+            }
+        }
+        self.dirty_lines.extend(rows);
+    }
+
+    fn delete_columns(&mut self, col: usize, n: u16) {
+        let n = as_usize(n, 1);
+        let cols_left = self.cols.saturating_sub(col);
+        let shift = n.min(cols_left);
+        if shift == 0 {
+            return;
+        }
         let rows = self.top_margin..self.bottom_margin + 1;
         for row in rows.clone() {
             self.buffer.delete((col, row), shift, &self.pen);
@@ -2799,6 +2831,46 @@ mod tests {
         term.execute(Decdc(0));
 
         assert_eq!(text(&term), "|bcdefgh");
+    }
+
+    #[test]
+    fn execute_sl() {
+        // SL shifts every row left, regardless of cursor column.
+        let mut term = build_term(8, 2, 5, 0, "abcdefghIJKLMNOP");
+
+        term.execute(Sl(3));
+
+        // The cursor row text trims trailing spaces past the cursor;
+        // the second row is also shifted because SL operates over
+        // the whole scroll region.
+        assert_eq!(text(&term), "defgh|\nLMNOP");
+    }
+
+    #[test]
+    fn execute_sl_default_param_is_one() {
+        let mut term = build_term(8, 1, 0, 0, "abcdefgh");
+
+        term.execute(Sl(0));
+
+        assert_eq!(text(&term), "|bcdefgh");
+    }
+
+    #[test]
+    fn execute_sr() {
+        let mut term = build_term(8, 2, 5, 0, "abcdefghIJKLMNOP");
+
+        term.execute(Sr(3));
+
+        assert_eq!(text(&term), "   ab|cde\n   IJKLM");
+    }
+
+    #[test]
+    fn execute_sr_default_param_is_one() {
+        let mut term = build_term(8, 1, 0, 0, "abcdefgh");
+
+        term.execute(Sr(0));
+
+        assert_eq!(text(&term), "| abcdefg");
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -950,7 +950,13 @@ impl Terminal {
                 self.dirty_lines.extend(0..self.rows);
             }
 
-            _ => {}
+            EdScope::SavedLines => {
+                // CSI 3 J: erase scrollback only. The visible view is
+                // untouched, the cursor doesn't move. Implementations
+                // vary on whether this is a no-op when scrollback is
+                // disabled; we drain whatever scrollback exists.
+                self.buffer.clear_scrollback();
+            }
         }
     }
 
@@ -2543,6 +2549,38 @@ mod tests {
 
         assert_eq!(text(&term), "\n |\n");
         assert_eq!(wrapped(&term), vec![false, false, false]);
+    }
+
+    #[test]
+    fn execute_ed_saved_lines() {
+        // Build a buffer with scrollback: 2-row view + scrollback
+        // capacity. Feed 5 lines so 3 spill into scrollback.
+        let mut term = Terminal::new((4, 2), Some(10));
+        feed(&mut term, "L0\r\nL1\r\nL2\r\nL3\r\nL4");
+
+        assert!(term.lines().count() > 2, "expected scrollback to exist");
+        let view_before: Vec<String> = term.view().map(|l| l.text()).collect();
+
+        term.execute(Ed(EdScope::SavedLines));
+
+        // Scrollback drained, view intact, cursor unchanged.
+        assert_eq!(term.lines().count(), 2);
+        let view_after: Vec<String> = term.view().map(|l| l.text()).collect();
+        assert_eq!(view_after, view_before);
+        assert_eq!(term.cursor(), (2, 1));
+    }
+
+    #[test]
+    fn execute_ed_saved_lines_no_scrollback() {
+        // No scrollback buffered → ED 3 is a no-op for state but
+        // must not panic / corrupt anything.
+        let mut term = Terminal::new((4, 3), Some(10));
+        feed(&mut term, "abc");
+
+        term.execute(Ed(EdScope::SavedLines));
+
+        assert_eq!(text(&term), "abc|\n\n");
+        assert_eq!(term.lines().count(), 3);
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1039,7 +1039,7 @@ impl Terminal {
         };
 
         self.buffer
-            .scroll_up(range.clone(), as_usize(n, 1), &self.pen);
+            .delete_lines(range.clone(), as_usize(n, 1), &self.pen);
 
         self.dirty_lines.extend(range);
     }
@@ -1059,7 +1059,14 @@ impl Terminal {
     }
 
     fn su(&mut self, n: u16) {
-        self.scroll_up_in_region(as_usize(n, 1));
+        // Explicit SU (CSI Pn S) discards lines that scroll off the
+        // top of the scroll region — they don't enter the scrollback
+        // buffer. Use the explicit-delete path; only natural overflow
+        // (LF / wrap at the bottom margin) preserves history.
+        let range = self.top_margin..self.bottom_margin + 1;
+        self.buffer
+            .delete_lines(range.clone(), as_usize(n, 1), &self.pen);
+        self.dirty_lines.extend(range);
     }
 
     fn sd(&mut self, n: u16) {
@@ -2495,6 +2502,50 @@ mod tests {
 
         assert_eq!(text(&term), "abcd\nefgh\nijkl\n|");
         assert_eq!(wrapped(&term), vec![true, true, false, false]);
+    }
+
+    #[test]
+    fn dl_at_top_row_does_not_grow_scrollback() {
+        // DL discards the deleted line — it must not be pushed into
+        // the scrollback buffer even when the deletion happens at
+        // the top of the viewport and the full row range is involved.
+        let mut term = Terminal::new((4, 3), Some(20));
+        feed(&mut term, "AAA\r\nBBB\r\nCCC");
+
+        let scrollback_before = term.lines().count() - term.size().1;
+        assert_eq!(scrollback_before, 0, "preconditions");
+
+        term.execute(Cup(1, 1));
+        term.execute(Dl(1));
+
+        // BBB shifted up, CCC shifted up, last row blank. AAA gone.
+        let visible: Vec<String> = term
+            .view()
+            .map(|l| l.text().trim_end().to_owned())
+            .collect();
+        assert_eq!(visible, vec!["BBB", "CCC", ""]);
+        assert_eq!(term.lines().count(), 3);
+    }
+
+    #[test]
+    fn su_does_not_grow_scrollback() {
+        // SU is an explicit scroll, not a natural overflow — it
+        // should drop the lines that leave the top of the scroll
+        // region, never preserving them in the scrollback buffer.
+        let mut term = Terminal::new((4, 3), Some(20));
+        feed(&mut term, "AAA\r\nBBB\r\nCCC");
+
+        let scrollback_before = term.lines().count() - term.size().1;
+        assert_eq!(scrollback_before, 0, "preconditions");
+
+        term.execute(Su(2));
+
+        let visible: Vec<String> = term
+            .view()
+            .map(|l| l.text().trim_end().to_owned())
+            .collect();
+        assert_eq!(visible, vec!["CCC", "", ""]);
+        assert_eq!(term.lines().count(), 3);
     }
 
     #[test]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -750,6 +750,11 @@ impl Terminal {
     fn print(&mut self, mut ch: char) {
         ch = self.charsets[self.active_charset].translate(ch);
 
+        if is_combining_mark(ch) {
+            self.attach_combining(ch);
+            return;
+        }
+
         match self.try_print(ch) {
             PrintResult::Printed(width) => self.advance_cursor_after_print(width),
             PrintResult::Overshoot if self.auto_wrap_mode => {
@@ -770,6 +775,33 @@ impl Terminal {
 
         self.last_print_char = Some(ch);
         self.dirty_lines.add(self.cursor.row);
+    }
+
+    /// Attach a zero-width combining mark to the most recently
+    /// written cell. The "most recent cell" is the one immediately
+    /// to the left of the cursor (or two left of it if the cursor
+    /// sits on the tail of a wide character), and the mark is
+    /// dropped entirely when no such cell exists — e.g. at column 0
+    /// of a fresh row, before the first printable.
+    fn attach_combining(&mut self, ch: char) {
+        if self.cursor.col == 0 {
+            // Combining marks before the first printable on a row
+            // have nothing to bind to; drop them. xterm.js follows
+            // the same convention.
+            return;
+        }
+
+        let row = self.cursor.row;
+        // When auto-wrap has parked the cursor past the last column
+        // the mark still belongs to the glyph in the last column.
+        let mut attach_col = self.cursor.col.min(self.cols) - 1;
+
+        if self.buffer[(attach_col, row)].occupancy() == Occupancy::WideTail && attach_col > 0 {
+            attach_col -= 1;
+        }
+
+        self.buffer.push_combining((attach_col, row), ch);
+        self.dirty_lines.add(row);
     }
 
     fn try_print(&mut self, ch: char) -> PrintResult {
@@ -1670,14 +1702,14 @@ impl Terminal {
         if self.cursor.col >= self.cols {
             // move cursor past the right border by re-printing the character in
             // the last column
-            let last_cell = self.buffer[(self.cols - 1, self.cursor.row)];
+            let last_cell = &self.buffer[(self.cols - 1, self.cursor.row)];
             let occupancy = last_cell.occupancy();
 
             if occupancy == Occupancy::Single {
                 funs.push(to_sgr(last_cell.pen()));
                 funs.push(Function::Print(last_cell.char()));
             } else if occupancy == Occupancy::WideTail {
-                let prev_cell = self.buffer[(self.cols - 2, self.cursor.row)];
+                let prev_cell = &self.buffer[(self.cols - 2, self.cursor.row)];
 
                 funs.push(Function::Cub(1));
                 funs.push(to_sgr(prev_cell.pen()));
@@ -1875,10 +1907,25 @@ fn dump_cells(cells: &[Cell], funs: &mut Vec<Function>) {
     let mut i = 0;
 
     while i < cells.len() {
+        // Cells that carry combining marks are dumped individually
+        // — neither REP nor a plain run-length share applies once
+        // the trailing marks have to be re-emitted after each base.
+        if !cells[i].combining().is_empty() {
+            funs.push(Function::Print(cells[i].char()));
+            for mark in cells[i].combining() {
+                funs.push(Function::Print(*mark));
+            }
+            i += 1;
+            continue;
+        }
+
         let ch = cells[i].char();
         let mut run_len = 1;
 
-        while i + run_len < cells.len() && cells[i + run_len].char() == ch {
+        while i + run_len < cells.len()
+            && cells[i + run_len].char() == ch
+            && cells[i + run_len].combining().is_empty()
+        {
             run_len += 1;
         }
 
@@ -1952,6 +1999,17 @@ fn as_usize(value: u16, default: usize) -> usize {
     } else {
         value as usize
     }
+}
+
+/// True for Unicode characters with display width 0 — combining
+/// marks, variation selectors, zero-width joiners, etc. ASCII is
+/// short-circuited to false. These attach to the preceding cell
+/// rather than consuming a cell of their own.
+fn is_combining_mark(ch: char) -> bool {
+    if ch <= '\u{7e}' {
+        return false;
+    }
+    matches!(unicode_width::UnicodeWidthChar::width(ch), Some(0))
 }
 
 impl Default for Terminal {
@@ -2201,6 +2259,52 @@ mod tests {
         term.execute(Bs);
 
         assert_eq!(text(&term), "abcd\n|ef");
+    }
+
+    #[test]
+    fn combining_mark_attaches_to_previous_cell() {
+        // U+0301 COMBINING ACUTE ACCENT has display width 0 — it
+        // should attach to the cell to its left without taking a
+        // column of its own.
+        let mut term = Terminal::new((10, 1), None);
+
+        feed(&mut term, "e\u{0301}X");
+
+        assert_eq!(term.cursor(), (2, 0));
+
+        let row = term.view().next().unwrap();
+        assert_eq!(row.text().trim_end(), "e\u{0301}X");
+        assert_eq!(row.cells()[0].combining(), &['\u{0301}'][..]);
+        // The second cell holds X with no marks of its own.
+        assert!(row.cells()[1].combining().is_empty());
+    }
+
+    #[test]
+    fn combining_mark_at_row_start_is_dropped() {
+        // With no preceding cell to bind to, the mark is silently
+        // discarded. This matches xterm.js.
+        let mut term = Terminal::new((10, 1), None);
+
+        feed(&mut term, "\u{0301}X");
+
+        assert_eq!(term.cursor(), (1, 0));
+        let row = term.view().next().unwrap();
+        assert_eq!(row.text().trim_end(), "X");
+    }
+
+    #[test]
+    fn combining_mark_attaches_to_wide_head_through_tail() {
+        // The cursor follows a wide glyph: cursor.col-1 is the
+        // wide-tail. The mark should still resolve to the head.
+        let mut term = Terminal::new((10, 1), None);
+
+        feed(&mut term, "ハ\u{0301}");
+
+        let row = term.view().next().unwrap();
+        assert_eq!(row.cells()[0].char(), 'ハ');
+        assert_eq!(row.cells()[0].combining(), &['\u{0301}'][..]);
+        // No combining mark sitting on the tail cell.
+        assert!(row.cells()[1].combining().is_empty());
     }
 
     #[test]

--- a/src/vt.rs
+++ b/src/vt.rs
@@ -1,6 +1,6 @@
 use crate::line::Line;
 use crate::parser::{self, Parser};
-use crate::terminal::{Cursor, Terminal};
+use crate::terminal::{BufferType, Cursor, Terminal};
 
 #[derive(Debug)]
 pub struct Vt {
@@ -69,6 +69,14 @@ impl Vt {
 
     pub fn cursor_key_app_mode(&self) -> bool {
         self.terminal.cursor_keys_app_mode()
+    }
+
+    /// Currently active screen buffer. Switches to
+    /// [`BufferType::Alternate`] when the application enters the
+    /// alternate screen (DECSET 1047 / 1049 / 47) and back to
+    /// [`BufferType::Primary`] when it leaves.
+    pub fn active_buffer_type(&self) -> BufferType {
+        self.terminal.active_buffer_type()
     }
 
     pub fn dump(&self) -> String {
@@ -211,6 +219,29 @@ mod tests {
         vt.resize(4, 3);
 
         assert_eq!(vt.size(), (4, 3));
+    }
+
+    #[test]
+    fn active_buffer_type_tracks_alternate_screen() {
+        use super::BufferType;
+
+        let mut vt = Vt::new(4, 2);
+
+        assert_eq!(vt.active_buffer_type(), BufferType::Primary);
+
+        // DECSET 1049: enter alternate screen.
+        vt.feed_str("\x1b[?1049h");
+        assert_eq!(vt.active_buffer_type(), BufferType::Alternate);
+
+        // DECRST 1049: leave alternate screen.
+        vt.feed_str("\x1b[?1049l");
+        assert_eq!(vt.active_buffer_type(), BufferType::Primary);
+
+        // DECSET 47 (legacy alt-screen toggle).
+        vt.feed_str("\x1b[?47h");
+        assert_eq!(vt.active_buffer_type(), BufferType::Alternate);
+        vt.feed_str("\x1b[?47l");
+        assert_eq!(vt.active_buffer_type(), BufferType::Primary);
     }
 
     #[test]


### PR DESCRIPTION
This series brings `avt` in line with [xterm.js](https://github.com/xtermjs/xterm.js) (the renderer most browser-side terminals use today) for a corpus of 159 real-world VT sequences that previously diverged. Every commit is self-contained — code + unit tests + property tests stay green at each step.

## Features

- **`feat: implement CSI 3 J (ED, erase scrollback)`** — the third argument to ED now clears scrollback; previously only `0`/`1`/`2` were handled. xterm.js, alacritty, kitty, and most modern terminals support this.
- **`feat: expose active buffer type on Vt`** — adds `Vt::active_buffer_type()` returning a new public `BufferType` (`Primary` / `Alternate`). Consumers that need to know whether the alternate screen is active can stop sniffing the `dump()` output.
- **`feat: implement DECIC and DECDC (insert/delete columns)`** — CSI `Pn '}` and CSI `Pn '~` insert/delete columns at the cursor column for every row of the scroll region. As a side improvement the CSI dump emitter now puts private-mode prefixes (`?`, `<`, `>`, `=`) before the parameter run while keeping other intermediate bytes (`'`, `!`, etc.) after it — matching how the parser's own state machine treats them.
- **`feat: implement SL and SR (scroll left / right)`** — CSI `Pn SP @` and CSI `Pn SP A` shift every row of the active scroll region left/right by `Pn` columns. Both reuse the column-shift primitives added for DECIC/DECDC.
- **`feat: implement reverse-wrap mode (DEC private mode 45)`** — `DECSET 45` enables XTREVWRAP; a backspace at column 0 of a soft-wrapped continuation row hops back to the last column of the predecessor. Hard line breaks still block the rewind.
- **`feat: render combining marks on the preceding cell`** — zero-width characters (Unicode combining marks, variation selectors, ZWJ) attach to the cell on their left instead of consuming a column and shifting the cursor. `Cell` carries an inline list of trailing marks; line iteration interleaves base + marks; the dump path emits each mark as its own `Print` so round-trips preserve them.

## Fixes

- **`fix: park cursor in overshoot position when auto-wrap is off`** — after writing into the last column with DECAWM off, the cursor now sits at column `cols` (the "pending wrap" overshoot) instead of being clamped to `cols-1`. Matches what every interactive terminal exposes.
- **`fix: REP repeats the last printable, clears on any other operation`** — REP now repeats the last `Print(char)` instead of re-reading the cell under the cursor. Any non-print/non-REP function clears the cached character so a cursor move between print and REP makes REP a no-op (xterm de-facto behaviour).
- **`fix: DL and SU drop lines instead of pushing them to scrollback`** — DL (delete lines) and SU (scroll up) now discard removed lines rather than promoting them to scrollback. xterm.js, alacritty, kitty, iTerm all behave this way; the previous behaviour duplicated content into scrollback that the user never saw on screen.
- **`fix: DECALN homes the cursor`** — DECALN (`ESC # 8`) now resets the cursor to the home position after filling the screen with E's. This is part of the original DEC VT100 spec.
- **`fix: drop wide glyph at right edge when auto-wrap is off`** — a width-2 glyph that would straddle the right edge is silently discarded when DECAWM is off, instead of overwriting the previous cell and parking the cursor in overshoot. Splits the previous "needs relocation" state into "wide-at-edge" and "overshoot" so the two cases can take different paths.
- **`fix: emit reverse-wrap mode in the terminal dump`** — `Vt::dump()` now serialises XTREVWRAP alongside the other modes so dump → re-feed reproduces it.

## How this was verified

All commits keep `cargo test` green (125 unit + property tests after the series). On top of that the changes are validated against an out-of-tree corpus of 175 real-world VT scenarios driven by a `@xterm/headless` oracle (a forked sub-process driven over JSON), confirming byte-for-byte agreement with the browser-side renderer.

I'm happy to break the series up further, rebase, or split commits if that helps review.
