### PR TITLE
bench: use iter::repeat_n for clippy::manual_repeat_n

### DIFF
--- a/benches/vt.rs
+++ b/benches/vt.rs
@@ -115,9 +115,7 @@ fn gen_newlines(scrollback_limit: usize) -> impl Fn() -> (Vt, Vec<String>) {
             .scrollback_limit(scrollback_limit)
             .build();
 
-        let chunks = iter::repeat(".\n".to_owned())
-            .take(100_000)
-            .collect::<Vec<_>>();
+        let chunks = iter::repeat_n(".\n".to_owned(), 100_000).collect::<Vec<_>>();
 
         (vt, chunks)
     }


### PR DESCRIPTION
clippy 1.81 added the `manual_repeat_n` lint, which fires on `iter::repeat(x).take(n).collect()` and recommends the more direct `iter::repeat_n(x, n).collect()`.

No behavioural change; functionally identical, just less idiomatic-by-2024-standards. Drive-by patch independent of any other work.